### PR TITLE
Added __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+# For relative imports to work as expected
+import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))


### PR DESCRIPTION
Importing `nexar_token.py` from another script outside this directory currently causes a relative import failure on `from local_service import handlerFactory`. This addition of `__init__.py` adds the directory to the system path, allowing the relative import to work as expected. Tested with `print_token.py` from this directory, and with `from nexar_token_py.nexar_token import get_token` in a script from a parent directory.